### PR TITLE
Add Docker build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang
+
+COPY . $GOPATH/src/github.com/staaldraad/tcpprox/
+WORKDIR $GOPATH/src/github.com/staaldraad/tcpprox/
+
+RUN go build -v
+
+ENTRYPOINT [ "./tcpprox", "-l", "0.0.0.0" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
Using the official Golang image, 'latest' tag. More info at https://hub.docker.com/_/golang/

Just adding files, setting working dir and running build. ENTRYPOINT has also included the ```-l 0.0.0.0``` command line switch to allow the program to be contacted from outside of the container. Otherwise, the service would be not reachable, since 127.0.0.1 would apply to the container's internal network interface.

Build image:
```
$ docker build -t tcpprox .
```

Run:
```
$ docker run --rm -it -p [ext_port:port] -v [your_config_file]:/etc/tcpprox.conf:ro tcpprox [other options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:
```
$ docker run --rm -it -p [ext_port:port] -v [your_config_file]:/etc/tcpprox.conf:ro pataquets/tcpprox-src [other options...]
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Should stop by `CTRL+C`'ing it.
In order for the Docker container to connect to external hosts, they should be contactable as external IPs or hosts or be linked to other previously run Docker containers via Docker's ```--link``` option.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.
- If an 'official' public image is available, I can submit my demo/testing Docker Compose manifest demo'ing tcpprox in front of a memcached, to serve as an example (now it refers to my user's Docker Hub image).