### PR TITLE
Add example Docker Compose manifest.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+# Example testing Docker Compose manifest (same as readme). Usage:
+# $ curl --insecure --header https://localhost:8000
+tcpprox:
+  container_name: tcpprox
+  build: .
+#  image: staaldraad/tcpprox
+  command: -p 8000 -s -r google.com:443
+  ports:
+    - "8000:8000"


### PR DESCRIPTION
Created for testing while diagnosing a problem, which ended being an error on my part.
Also, I've found that the official Docker Hub image is not automatically built from source, which goes against auditability and traceability. I've had to check build times, versions and all to be sure it was not an image's problem.
I think it would be better to set up an [Automated Build from source](https://docs.docker.com/docker-hub/builds). How about it?