### PR TITLE
Add mTLS to tcpprox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+build:
+	go build -o tcpprox tcpprox.go
+
+run:
+	go run tcpprox.go
+	
+build all:
+	# 32-bit
+	# Linux
+	GOOS=linux GOARCH=386 go build -o tcpprox-linux86
+	sha256sum  tcpprox-linux86 
+	# Windows
+	GOOS=windows GOARCH=386 go build -o tcpprox-win86.exe 
+	sha256sum  tcpprox-win86.exe 
+	# OSX
+	GOOS=darwin GOARCH=386 go build -o tcpprox-osx86
+	sha256sum  tcpprox-osx86
+
+	# 64-bit
+	# Linux
+	GOOS=linux GOARCH=amd64 go build -o tcpprox-linux64
+	sha256sum  tcpprox-linux64      
+	# Windows
+	GOOS=windows GOARCH=amd64 go build -o tcpprox-win64.exe  
+	sha256sum  tcpprox-win64.exe
+ 	# OSX
+	GOOS=darwin GOARCH=amd64 go build -o tcpprox-osx64
+	sha256sum  tcpprox-osx64

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ If proxying a connection where the upstream server uses mTLS, tcpprox can be con
 tcpprox -s -c config.json -cert server.pem -key server.key -clientCert client.pem -clientKey client.key
 ```
 
+The application that is being proxied through tcpprox does not have to supply a client certificate (although it can). 
+
+This allows for either:
+
+```
+client <---TLS---> tcpprox <---mTLS---> server
+```
+
+or
+
+```
+client <---mTLS---> tcpprox <---mTLS---> server
+```
+
+Tcpprox will allow both types of connections through, as long as tcpprox is able to use mTLS to connect to the server, the client is oblivious of what is happening upstream.
+
 ## Config File
 
 The config file can be used instead of supplying all information on the command line. The options specified in the file will be overwritten by any matching command line arguments. This allows for using a config file and overriding one or more options for testing / variation between hosts.

--- a/README.md
+++ b/README.md
@@ -10,27 +10,49 @@ _The command line arguments have precidence and override the config file_
 
 To create a TLS proxy using the supplied config file:
 
-`tcpprox -s -c config.json -r 172.16.0.12:4550`
+```
+tcpprox -s -c config.json -r 172.16.0.12:4550
+```
 
 To create a normal TCP proxy,  no config file:
 
-`tcpprox -l 0.0.0.0 -p 8081 -r 172.16.0.12:8081`
+```
+tcpprox -l 0.0.0.0 -p 8081 -r 172.16.0.12:8081
+```
 
-To specify a custom certificate to use (PEM format) you can use the -cert option:
+To specify a custom certificate to use (PEM format) you can use the -cert and -key options (must be used together):
 
-`tcpprox -s -c config.json -cert server`
+___Note (breaking change)__ for previous versions of tcpprox, the `-cert` and `-key` arguments were combined into one argument `-cert`. This previous arg would take the supplied value and automatically append **.pem** and **.key**. This is no longer the case and the supplied filepaths for `-cert` and `-key` must be complete and for valid, matching files._   
 
-Where server is the prefix to server.pem and server.key (I'm lazy...)
+```
+tcpprox -s -c config.json -cert server.pem -key server.key
+```
+
 To generate valid certificate and key:
 
-`
+```
 openssl genrsa -out server.key 2048
 openssl req -new -x509 -key server.key -out server.pem -days 3650
-`
+```
+
 To convert the certificate to DER format:
 
-`openssl x509 -in server.pem -out server.crt -outform der`
+```
+openssl x509 -in server.pem -out server.crt -outform der
+```
 
+
+## mTLS
+
+If proxying a connection where the upstream server uses mTLS, tcpprox can be configured to use mTLS to authenticate.
+
+```
+tcpprox -s -c config.json -cert server.pem -key server.key -clientCert client.pem -clientKey client.key
+```
+
+## Config File
+
+The config file can be used instead of supplying all information on the command line. The options specified in the file will be overwritten by any matching command line arguments. This allows for using a config file and overriding one or more options for testing / variation between hosts.
 
 # Using Docker
 

--- a/config.json
+++ b/config.json
@@ -7,5 +7,8 @@
             "Org":["Staaldraad"],
             "CommonName":"*.domain.com"
     },
-    "Certfile":""
+    "CACertFile":"",
+    "CAKeyFile":"",
+    "ClientCertFile":"",
+    "ClientKeyFile":"" 
 }


### PR DESCRIPTION
**Breaking Changes**

* splits `-cert` into `-cert` and `-key` to allow setting distinct paths to the caCert and private key
* applies to the config file as well

**Adds**
* mTLS support. If the upstream server uses mTLS for authentication, tcpprox can now supply a client certificate for authentication
* mTLS is done through config file or `-clientCert` and `-clientKey`
