### PR TITLE
Alt names

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,5 +10,7 @@
     "CACertFile":"",
     "CAKeyFile":"",
     "ClientCertFile":"",
-    "ClientKeyFile":"" 
+    "ClientKeyFile":"",
+    "IPS" : [],
+    "Names" : []
 }

--- a/tcpprox.go
+++ b/tcpprox.go
@@ -303,8 +303,6 @@ func main() {
 
 	setConfig(*configPtr, *localPort, *localHost, *remoteHostPtr, *caCertFilePtr, *caKeyFilePtr, *clientCertPtr, *clientKeyPtr)
 
-	config.IPS = []string{"192.168.1.1"}
-
 	if config.Remotehost == "" {
 		fmt.Println("[x] Remote host required")
 		flag.PrintDefaults()

--- a/tcpprox.go
+++ b/tcpprox.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"math/big"
 	"net"
 	"os"
 	"time"
@@ -42,8 +41,9 @@ var config Config
 var ids = 0
 
 func genCert() ([]byte, *rsa.PrivateKey) {
+	s, _ := rand.Prime(rand.Reader, 128)
 	ca := &x509.Certificate{
-		SerialNumber: big.NewInt(128),
+		SerialNumber: s,
 		Subject: pkix.Name{
 			Country:      config.TLS.Country,
 			Organization: config.TLS.Org,
@@ -184,9 +184,9 @@ func startListener(isTLS bool) {
 			cert, _ = tls.LoadX509KeyPair(config.CACertFile, config.CAKeyFile)
 		} else {
 			fmt.Println("[*] Generating cert")
-			ca_b, priv := genCert()
+			cab, priv := genCert()
 			cert = tls.Certificate{
-				Certificate: [][]byte{ca_b},
+				Certificate: [][]byte{cab},
 				PrivateKey:  priv,
 			}
 		}


### PR DESCRIPTION
Adds the ability to use a signing cert for the proxy, which will then generate and sign child certificates for the upstream host (child cert will have IP/hostname set in SNI)