### PR TITLE
Add -raw and output to file options. Speed improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,44 @@ docker run -it --rm -p 8000:8000 staaldraad/tcpprox:latest -p 8000 -s -r google.
 
 This will create a TLS enabled listener on port 8000 and proxy traffic to google.com:443
 
+
+**Something about performance**
+
+Method of outputting (displaying) the data being proxied determines how close to "non-proxied" performance you get.
+
+* Running with `-raw -o /path/to/file` gives near native speed. AKA, it is as if the proxy isn't there. 
+* Running with `-o /path/to/file` is almost as fast
+* Outputting the hex.dump directly to screen is the slowest option. To get better speed, output hex to a file and use `tail -f /path/to/file`. It is still a little slower (depending on hardware) but better than direct to screen.
+
+Direct to screen with hex dump formatting (default): `./tcproxy -p 8000 user@remote`
+```
+$ scp -P 8000 root@localhost:file.txt /tmp/p
+file.txt                                                                                    100%   10MB   2.1MB/s   00:04    
+```
+
+Write to file with hex dump formatting: `./tcproxy -p 8000 user@remote -o /tmp/session`
+```
+$ scp -P 8000 root@localhost:file.txt /tmp/p
+file.txt                                                                                    100%   10MB  10.2MB/s   00:00      
+```
+
+Write raw stream to file: `./tcproxy -p 8000 user@remote -o /tmp/session -raw`
+```
+$ scp -P 8000 root@localhost:file.txt /tmp/p
+file.txt                                                                                    100%   10MB  10.7MB/s   00:00    
+
+```
+
+Write to file with hex dump formatting: `./tcproxy -p 8000 user@remote -o /tmp/session ` and use tail to view live stream: `tail -f /tmp/session`
+```
+$ scp -P 8000 root@localhost:file.txt /tmp/p
+file.txt                                                                                    100%   10MB   5.9MB/s   00:01    
+
+```
+
+And raw (no output at all): `./tcproxy -p 8000 user@remote -raw`
+
+```
+$ scp -P 8000 root@localhost:file.txt /tmp/p
+file.txt                                                                                    100%   10MB  12.2MB/s   00:00    
+```

--- a/tcpprox.go
+++ b/tcpprox.go
@@ -116,12 +116,12 @@ func genChildCert(cert tls.Certificate, ips, names []string) []byte {
 
 func dumpData(r io.Reader, source string, id int) {
 
+	data := make([]byte, 512)
 	for {
-		data := make([]byte, 1024)
 		n, err := r.Read(data)
 		if n > 0 {
 			fmt.Printf("From %s [%d]:\n", source, id)
-			fmt.Printf("%s\n", hex.Dump(data[:n]))
+			fmt.Println(hex.Dump(data[:n]))
 		}
 		if err != nil {
 			break


### PR DESCRIPTION
running with `-raw -o /path/to/file` gives near native speed. AKA, it is as if the proxy isn't there. 
running with `-o /path/to/file` is almost as fast
outputting the hex.dump directly to screen is the slowest option. To get better speed, output hex to a file and use `tail -f /path/to/file`. It is still a little slower (depending on hardware) but better than direct to screen.

Using `./tcproxy -p 8000 user@remote`
```
$ scp -P 8000 root@localhost:file.txt /tmp/p
file.txt                                                                                    100%   10MB   2.1MB/s   00:04    
```

Using `./tcproxy -p 8000 user@remote -o /tmp/session`
```
$ scp -P 8000 root@localhost:file.txt /tmp/p
file.txt                                                                                    100%   10MB  10.2MB/s   00:00      
```

Using `./tcproxy -p 8000 user@remote -o /tmp/session -raw`
```
$ scp -P 8000 root@localhost:file.txt /tmp/p
file.txt                                                                                    100%   10MB  10.7MB/s   00:00    

```

Using `./tcproxy -p 8000 user@remote -o /tmp/session ` and `tail -f /tmp/session`
```
$ scp -P 8000 root@localhost:file.txt /tmp/p
file.txt                                                                                    100%   10MB   5.9MB/s   00:01    

```
